### PR TITLE
fix: abusive creation of HttpClient and small cleanups

### DIFF
--- a/WarframeClient/Functions.cs
+++ b/WarframeClient/Functions.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using System.Net.Http;
 using Newtonsoft.Json;
 
@@ -6,6 +7,8 @@ namespace WarframeNET
 {
     internal static class Functions
     {
+        private static readonly Lazy<HttpClient> persistentClient = new Lazy<HttpClient>();
+
         public static string ToCamel(string text)
         {
             char firstCamel = text[0];
@@ -22,19 +25,16 @@ namespace WarframeNET
 
         public static async Task<WorldState> GetWorldStateAsync(string platform)
         {
-            using (var client = new HttpClient())
-            {
                 #pragma warning disable 0618
                 string endpoint = Endpoint.WorldState + platform;
                 #pragma warning restore 0618
 
-                var response = await client.GetAsync(endpoint);
+                var response = await persistentClient.Value.GetAsync(endpoint);
                 response.EnsureSuccessStatusCode();
                 var json = await response.Content.ReadAsStringAsync();
                 WorldState state = JsonConvert.DeserializeObject<WorldState>(json);
 
                 return state;
-            }
         }
     }
 }

--- a/WarframeClient/Platform.cs
+++ b/WarframeClient/Platform.cs
@@ -28,6 +28,6 @@
         /// <summary>
         /// List of correct platforms.
         /// </summary>
-        public static string[] List = { PC, PSFOUR, XBOXONE, SWITCH };
+        public static string[] List { get; } = {PC, PSFOUR, XBOXONE, SWITCH};
     }
 }

--- a/WarframeObjects/Cetuscycle.cs
+++ b/WarframeObjects/Cetuscycle.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace WarframeNET
 {
     public class CetusCycle


### PR DESCRIPTION
HTTP requests are now made by a single instance of HttpClient, as recommended in [doc](https://docs.microsoft.com/en-us/dotnet/api/system.net.http.httpclient?redirectedfrom=MSDN&view=netframework-4.8#remarks).
I also corrected a missing `using` in Cetuscycle.cs and encapsulated a property in `Platform`.